### PR TITLE
Run rubocop after generators

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,5 +42,10 @@ module SimpleBoardApi
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    config.generators.after_generate do |files|
+      parsable_files = files.filter { |file| file.end_with?('.rb') }
+      system("bundle exec rubocop -A --fail-level=E #{parsable_files.shelljoin}", exception: true)
+    end
   end
 end


### PR DESCRIPTION
## Task:
Autocorrect generated text with `rubocop`
## Change proposed in this pull request:
* Run `rubocop` after rails generators running